### PR TITLE
Update Sqlite backend to handle null values

### DIFF
--- a/tools/sigma/backends/sqlite.py
+++ b/tools/sigma/backends/sqlite.py
@@ -107,6 +107,9 @@ class SQLiteBackend(SQLBackend):
             self.mappingItem = True
             fieldname, value = node
             transformed_fieldname = self.fieldNameMapping(fieldname, value)
+
+            if value is None: value = '' # Handle null values
+
             generated_value = self.generateNode(value)
 
             has_wildcard = re.search(


### PR DESCRIPTION
When generating "default" rulesets for Zircolite, I took notice that null values (e.g `CurrentDirectory: null`) are not handled correctly by the base class.

**This is basically handled in the sqlite (not sql) backend just by replacing `None` by an empty string to avoid a Python Exception.**

**I know that `sigmac` has been deprecated in favour of pySigma** but for now the Sqlite backend hasn't been converted.